### PR TITLE
[hotfix] つり革の素材が一覧に追加されていなかったため急遽追加

### DIFF
--- a/src/data/materials/wwaMaterial.yml
+++ b/src/data/materials/wwaMaterial.yml
@@ -539,6 +539,12 @@
   tags:
     - WWA素材第3世代
     - 列車内装
+- name: 18train_interior-handstrap
+  file: /materials/wwa/18train_interior-handstrap.gif
+  publishedAt: 2020-03-01
+  tags:
+    - WWA素材第3世代
+    - 列車内装
 - name: 18train_interior-express1
   file: /materials/wwa/18train_interior-express1.gif
   publishedAt: 2020-03-01


### PR DESCRIPTION
#49 の追加修正(2)です。

つり革の素材を追加したのに一覧に存在せず、素材が取得できないことから急遽追加しました。