### PR TITLE
OGP の URL を絶対 URL に修正

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,7 @@ module.exports = {
     title: `Aokashi Home`,
     description: `Aokashi の個人サイトです。`,
     author: `@aokashi`,
+    siteUrl: `https://www.aokashi.net`,
     openGraphImage: `/images/ah-ogp_image.png`,
   },
   plugins: [

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -19,6 +19,7 @@ function SEO({ description, image, lang, meta, title }) {
             title
             description
             author
+            siteUrl
             openGraphImage
           }
         }
@@ -28,6 +29,7 @@ function SEO({ description, image, lang, meta, title }) {
 
   const metaDescription = description || site.siteMetadata.description
   const metaImage = image || site.siteMetadata.openGraphImage
+  const metaImageUrl = site.siteMetadata.siteUrl + metaImage
   const metaTitle = title === site.siteMetadata.title ? site.siteMetadata.title : `%s - ${site.siteMetadata.title}`
 
   return (
@@ -56,7 +58,7 @@ function SEO({ description, image, lang, meta, title }) {
         },
         {
           property: `og:image`,
-          content: metaImage,
+          content: metaImageUrl,
         },
         {
           name: `twitter:card`,
@@ -76,7 +78,7 @@ function SEO({ description, image, lang, meta, title }) {
         },
         {
           name: `twitter:image`,
-          content: metaImage
+          content: metaImageUrl,
         },
       ].concat(meta)}
     />


### PR DESCRIPTION
OGP の URL を絶対 URL に修正して、OGP 画像の読み込みをしやすくします。

## 目的
- OGP が正しく表示されない → OGP の画像 URL が絶対 URL になっていないので修正