### PR TITLE
ポートフォリオ記事のカルーセルの既定サイズを設定

### DIFF
--- a/src/templates/portfolio-item.js
+++ b/src/templates/portfolio-item.js
@@ -122,8 +122,8 @@ const PortfolioCarousel = ({ images }) => {
       return Math.max(currentMaxSize, currentSize)
     }
   }
-  const maxWidth = images.reduce(findMaxSize(gatsbyImage => gatsbyImage.childImageSharp.original.width), 0)
-  const maxHeight = images.reduce(findMaxSize(gatsbyImage => gatsbyImage.childImageSharp.original.height), 0)
+  const maxWidth = images.reduce(findMaxSize(gatsbyImage => gatsbyImage.childImageSharp.original.width), 1)
+  const maxHeight = images.reduce(findMaxSize(gatsbyImage => gatsbyImage.childImageSharp.original.height), 1)
 
   return (
     <div className={styles.images}>


### PR DESCRIPTION
#77 の続きです。
ポートフォリオの画像のサイズ読み込みに失敗した場合、画像ファイルが表示されなくなりますが、そうではなく、 1:1 の領域で表示するように修正します。