### PR TITLE
aokashi-boxのテーマ表記をスキン表記に修正

### DIFF
--- a/src/data/software.json
+++ b/src/data/software.json
@@ -44,7 +44,7 @@
   }, {
     "id": "aokashi_box",
     "name": "aokashi-box",
-    "description": "スマートフォンでも見れる Pukiwiki スキンです。",
+    "description": "スマートフォンでも見れる Pukiwiki のスキンです。",
     "repository": "https://github.com/aokashi/aokashi-box",
     "keywords": ["PHP"],
     "references": []

--- a/src/data/software.json
+++ b/src/data/software.json
@@ -44,7 +44,7 @@
   }, {
     "id": "aokashi_box",
     "name": "aokashi-box",
-    "description": "スマートフォンでも見れる Pukiwiki テーマです。",
+    "description": "スマートフォンでも見れる Pukiwiki スキンです。",
     "repository": "https://github.com/aokashi/aokashi-box",
     "keywords": ["PHP"],
     "references": []


### PR DESCRIPTION
Pukiwiki はテーマではなくスキンと呼ぶそうなので、表記を修正します。