### PR TITLE
ソーシャルアイコンに Discord を追加

### DIFF
--- a/src/data/socialLink.yml
+++ b/src/data/socialLink.yml
@@ -23,6 +23,9 @@
 - name: askfm
   link: https://ask.fm/aokashi
   text: aokashi
+- name: Discord
+  text: aokashi.towa
+  icon: discord
 - name: Twitch
   link: https://www.twitch.tv/aokashi_towa
   text: aokashi_towa


### PR DESCRIPTION
Discord のユーザー名制度移行に伴い、一意のユーザー名（と多分枠取られて普段のユーザー名では使用できないので異なるユーザー名を使用している旨）を表記するために、リンクはありませんが Discord を追加します。